### PR TITLE
Don't mess with the build type in GME's CMakeLists.txt

### DIFF
--- a/thirdparty/game-music-emu/CMakeLists.txt
+++ b/thirdparty/game-music-emu/CMakeLists.txt
@@ -8,11 +8,6 @@ include (CheckCXXCompilerFlag)
 # When version is changed, also change the one in gme/gme.h to match
 set(GME_VERSION 0.6.2 CACHE INTERNAL "libgme Version")
 
-# I don't plan on debugging this, so make it a release build.
-if( NOT CMAKE_BUILD_TYPE MATCHES "Release" )
-    set( CMAKE_BUILD_TYPE "RelWithDebInfo" )
-endif()
-
 if(COMPILER_IS_GNUCXX_COMPATIBLE)
     add_compile_options(-Wall -Wextra)
     if(NOT PROFILE)


### PR DESCRIPTION
It's currently not possible to make a Debug build of ZMusic. This is because GME has `CMAKE_BUILD_TYPE` restricted to just `Release` and `RelWithDebInfo`, while the rest of ZMusic respects `CMAKE_BUILD_TYPE`. This mismatch causes a long string of errors at link stage:

```
D:\src\ZMusic\out\build\x64-Debug\adlmidi_midiplay.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\adlmidi_midiplay.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\adlmidi_opl3.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\adlmidi_opl3.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\adlmidi_private.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\adlmidi_private.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\adlmidi.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\adlmidi.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\adlmidi_load.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\adlmidi_load.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\inst_db.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\inst_db.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\opal_opl3.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\opal_opl3.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\dbopl.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\dbopl.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\nuked_opl3_v174.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\nuked_opl3_v174.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\java_opl3.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\java_opl3.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\dosbox_opl3.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\dosbox_opl3.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\nuked_opl3.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\nuked_opl3.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\fmopl.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\fmopl.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\opl_mus_player.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\opl_mus_player.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\oplio.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\oplio.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\opnmidi_load.cpp.obj : error LNK2038: mismatch detected for '_ITERATOR_DEBUG_LEVEL': value '2' doesn't match value '0' in Effects_Buffer.cpp.obj
D:\src\ZMusic\out\build\x64-Debug\opnmidi_load.cpp.obj : error LNK2038: mismatch detected for 'RuntimeLibrary': value 'MTd_StaticDebug' doesn't match value 'MT_StaticRelease' in Effects_Buffer.cpp.obj
...and many more...
```
This PR removes the offending section from third-party/game-music-emu/CMakeLists.txt so the same `CMAKE_BUILD_TYPE` is used for everything.