### PR TITLE
Add missing standard library includes (fix build with GCC 13)

### DIFF
--- a/source/mididevices/music_adlmidi_mididevice.cpp
+++ b/source/mididevices/music_adlmidi_mididevice.cpp
@@ -34,6 +34,7 @@
 
 // HEADER FILES ------------------------------------------------------------
 
+#include <stdexcept>
 #include <stdlib.h>
 
 #include "zmusic/zmusic_internal.h"

--- a/source/mididevices/music_fluidsynth_mididevice.cpp
+++ b/source/mididevices/music_fluidsynth_mididevice.cpp
@@ -35,6 +35,7 @@
 // HEADER FILES ------------------------------------------------------------
 
 #include <mutex>
+#include <stdexcept>
 #include <stdio.h>
 #include <stdlib.h>
 #include "zmusic/zmusic_internal.h"

--- a/source/mididevices/music_opl_mididevice.cpp
+++ b/source/mididevices/music_opl_mididevice.cpp
@@ -35,6 +35,7 @@
 
 // HEADER FILES ------------------------------------------------------------
 
+#include <stdexcept>
 #include "zmusic/zmusic_internal.h"
 #include "mididevice.h"
 #include "zmusic/mus2midi.h"

--- a/source/mididevices/music_opnmidi_mididevice.cpp
+++ b/source/mididevices/music_opnmidi_mididevice.cpp
@@ -34,6 +34,7 @@
 
 // HEADER FILES ------------------------------------------------------------
 
+#include <stdexcept>
 #include "mididevice.h"
 #include "zmusic/zmusic_internal.h"
 

--- a/source/mididevices/music_timidity_mididevice.cpp
+++ b/source/mididevices/music_timidity_mididevice.cpp
@@ -34,6 +34,7 @@
 
 // HEADER FILES ------------------------------------------------------------
 
+#include <stdexcept>
 #include <stdlib.h>
 #include "mididevice.h"
 #include "zmusic/zmusic_internal.h"

--- a/source/mididevices/music_timiditypp_mididevice.cpp
+++ b/source/mididevices/music_timiditypp_mididevice.cpp
@@ -32,6 +32,7 @@
 **
 */
 
+#include <stdexcept>
 #include "mididevice.h"
 #include "zmusic/zmusic_internal.h"
 

--- a/source/mididevices/music_wavewriter_mididevice.cpp
+++ b/source/mididevices/music_wavewriter_mididevice.cpp
@@ -38,6 +38,7 @@
 #include "mididevice.h"
 #include "zmusic/m_swap.h"
 #include "fileio.h"
+#include <stdexcept>
 #include <errno.h>
 
 // MACROS ------------------------------------------------------------------

--- a/source/mididevices/music_wildmidi_mididevice.cpp
+++ b/source/mididevices/music_wildmidi_mididevice.cpp
@@ -34,6 +34,7 @@
 
 // HEADER FILES ------------------------------------------------------------
 
+#include <stdexcept>
 #include "mididevice.h"
 #include "zmusic/zmusic_internal.h"
 

--- a/source/musicformats/music_midi.cpp
+++ b/source/musicformats/music_midi.cpp
@@ -34,8 +34,9 @@
 
 // HEADER FILES ------------------------------------------------------------
 
-#include <string>
 #include <algorithm>
+#include <stdexcept>
+#include <string>
 #include <assert.h>
 #include "zmusic/zmusic_internal.h"
 #include "zmusic/musinfo.h"

--- a/source/streamsources/music_gme.cpp
+++ b/source/streamsources/music_gme.cpp
@@ -38,9 +38,11 @@
 //#define GME_DLL
 
 #include <algorithm>
+#include <mutex>
+#include <stdexcept>
+
 #include "streamsource.h"
 #include <gme/gme.h>
-#include <mutex>
 #include "fileio.h"
 
 // MACROS ------------------------------------------------------------------

--- a/source/streamsources/music_opl.cpp
+++ b/source/streamsources/music_opl.cpp
@@ -35,6 +35,8 @@
 
 #ifdef HAVE_OPL
 
+#include <stdexcept>
+
 #include "streamsource.h"
 #include "oplsynth/opl.h"
 #include "oplsynth/opl_mus_player.h"

--- a/source/zmusic/fileio.h
+++ b/source/zmusic/fileio.h
@@ -25,6 +25,7 @@
 #pragma once
 #include <stdio.h>
 #include <string.h>
+#include <cstdint>
 #include <vector>
 #include <string>
 


### PR DESCRIPTION
GCC 13 (as usual for new compiler releases) shuffles around some internal includes and so <cstdint> etc is no longer transitively included.

See https://www.gnu.org/software/gcc/gcc-13/porting_to.html.

Bug: https://bugs.gentoo.org/892814