### PR TITLE
Fixed 2 bugs that prevented GS banks from being selected.

### DIFF
--- a/source/mididevices/music_fluidsynth_mididevice.cpp
+++ b/source/mididevices/music_fluidsynth_mididevice.cpp
@@ -239,9 +239,10 @@ void FluidSynthMIDIDevice::HandleEvent(int status, int parm1, int parm2)
 
 void FluidSynthMIDIDevice::HandleLongEvent(const uint8_t *data, int len)
 {
-	if (len > 1 && (data[0] == 0xF0 || data[0] == 0xF7))
+	constexpr int excludedByteCount = 2;						// 0xF0 (first byte) and 0xF7 (last byte) are not given to FluidSynth.
+	if (len > excludedByteCount && data[0] == 0xF0 && data[len - 1] == 0xF7)
 	{
-		fluid_synth_sysex(FluidSynth, (const char *)data + 1, len - 1, NULL, NULL, NULL, 0);
+		fluid_synth_sysex(FluidSynth, (const char *)data + 1, len - excludedByteCount, NULL, NULL, NULL, 0);
 	}
 }
 

--- a/source/musicformats/music_midi.cpp
+++ b/source/musicformats/music_midi.cpp
@@ -815,13 +815,22 @@ int MIDIStreamer::FillBuffer(int buffer_num, int max_events, uint32_t max_time)
 	if (InitialPlayback)
 	{
 		InitialPlayback = false;
-		// Send the GS System Reset SysEx message.
+		// Send the GM System Enable SysEx message.
 		events[0] = 0;								// dwDeltaTime
 		events[1] = 0;								// dwStreamID
 		events[2] = (MEVENT_LONGMSG << 24) | 6;		// dwEvent
 		events[3] = MAKE_ID(0xf0, 0x7e, 0x7f, 0x09);	// dwParms[0]
 		events[4] = MAKE_ID(0x01, 0xf7, 0x00, 0x00);	// dwParms[1]
 		events += 5;
+
+		// Send the GS DT1 MODE SET GS Reset SysEx message.
+		events[0] = 0;									// dwDeltaTime
+		events[1] = 0;									// dwStreamID
+		events[2] = (MEVENT_LONGMSG << 24) | 11;		// dwEvent
+		events[3] = MAKE_ID(0xf0, 0x41, 0x7f, 0x42);	// dwParms[0]
+		events[4] = MAKE_ID(0x12, 0x40, 0x00, 0x7f);	// dwParms[1]
+		events[5] = MAKE_ID(0x00, 0x41, 0xf7, 0x00);	// dwParms[2]
+		events += 6;
 
 		// Send the full master volume SysEx message.
 		events[0] = 0;								// dwDeltaTime


### PR DESCRIPTION
I initially noticed that the Reverse Cymbal was being played instead of Reverse Snare at the beginning of "One Night in Neo Kobe City" track featured in DBP37: AUGER;ZENITH megawad. This was happening with both internal and external FluidSynth instances, as well as with Microsoft GS Wavetable Synth. I realized that they weren't reacting to Bank Select ControlChange MIDI messages.

After a lot of digging, I finally found out, what was causing it: a SysEx message sent by MIDIStreamer::FillBuffer function. It appears, there was a misunderstanding of its purpose: in the comment it's referred to as a "GS System Reset", but it's actually a "GM System Enable" message. It's primary effect is to switch the synth to a pure GM mode, with a system reset as a side effect.

I've decided to keep the message, so that any pure GM synth can perform a system reset, but I've changed the comment to properly reflect its identity. I've also added another SysEx message, called "GS DT1 MODE SET" to instruct the synth to switch to GS mode, if one is supported.

The change worked, but only with MSGSWS and external FluidSynth, not with internal FluidSynth. After more digging, I chanced upon a bug from all the way back in August 2010: the number of bytes reported to FluidSynth as comprising the SysEx message was 1 too big, as both first and last bytes needed to be excluded, not just the first one. This didn't matter for "GM System Enable" message, as when processing it, FluidSynth doesn't check the byte count. I've fixed the bug and added a clarifying comment.

These changes were only tested with internal and external FluidSynth and MSGSWS.