### PR TITLE
Eliminated build warnings

### DIFF
--- a/source/mididevices/music_fluidsynth_mididevice.cpp
+++ b/source/mididevices/music_fluidsynth_mididevice.cpp
@@ -130,10 +130,16 @@ FluidSynthMIDIDevice::FluidSynthMIDIDevice(int samplerate, std::vector<std::stri
 		throw std::runtime_error("Failed to create FluidSynth.\n");
 	}
 	fluid_synth_set_interp_method(FluidSynth, -1, fluidConfig.fluid_interp);
-	fluid_synth_set_reverb(FluidSynth, fluidConfig.fluid_reverb_roomsize, fluidConfig.fluid_reverb_damping,
-		fluidConfig.fluid_reverb_width, fluidConfig.fluid_reverb_level);
-	fluid_synth_set_chorus(FluidSynth, fluidConfig.fluid_chorus_voices, fluidConfig.fluid_chorus_level,
-		fluidConfig.fluid_chorus_speed, fluidConfig.fluid_chorus_depth, fluidConfig.fluid_chorus_type);
+	fluid_synth_set_reverb_group_roomsize(FluidSynth, -1, fluidConfig.fluid_reverb_roomsize);
+	fluid_synth_set_reverb_group_damp(FluidSynth, -1, fluidConfig.fluid_reverb_damping);
+	fluid_synth_set_reverb_group_width(FluidSynth, -1, fluidConfig.fluid_reverb_width);
+	fluid_synth_set_reverb_group_level(FluidSynth, -1, fluidConfig.fluid_reverb_level);
+	fluid_synth_set_chorus_group_nr(FluidSynth, -1, fluidConfig.fluid_chorus_voices);
+	fluid_synth_set_chorus_group_level(FluidSynth, -1, fluidConfig.fluid_chorus_level);
+	fluid_synth_set_chorus_group_speed(FluidSynth, -1, fluidConfig.fluid_chorus_speed);
+	fluid_synth_set_chorus_group_depth(FluidSynth, -1, fluidConfig.fluid_chorus_depth);
+	fluid_synth_set_chorus_group_type(FluidSynth, -1, fluidConfig.fluid_chorus_type);
+
 
 	// try loading a patch set that got specified with $mididevice.
 
@@ -320,11 +326,11 @@ void FluidSynthMIDIDevice::ChangeSettingInt(const char *setting, int value)
 	// fluid_settings_setint succeeded; update these settings in the running synth, too
 	else if (strcmp(setting, "synth.reverb.active") == 0)
 	{
-		fluid_synth_set_reverb_on(FluidSynth, value);
+		fluid_synth_reverb_on(FluidSynth, -1, value);
 	}
 	else if (strcmp(setting, "synth.chorus.active") == 0)
 	{
-		fluid_synth_set_chorus_on(FluidSynth, value);
+		fluid_synth_chorus_on(FluidSynth, -1, value);
 	}
 }
 
@@ -346,11 +352,18 @@ void FluidSynthMIDIDevice::ChangeSettingNum(const char *setting, double value)
 
 	if (strcmp(setting, "z.reverb") == 0)
 	{
-		fluid_synth_set_reverb(FluidSynth, fluidConfig.fluid_reverb_roomsize, fluidConfig.fluid_reverb_damping, fluidConfig.fluid_reverb_width, fluidConfig.fluid_reverb_level);
+		fluid_synth_set_reverb_group_roomsize(FluidSynth, -1, fluidConfig.fluid_reverb_roomsize);
+		fluid_synth_set_reverb_group_damp(FluidSynth, -1, fluidConfig.fluid_reverb_damping);
+		fluid_synth_set_reverb_group_width(FluidSynth, -1, fluidConfig.fluid_reverb_width);
+		fluid_synth_set_reverb_group_level(FluidSynth, -1, fluidConfig.fluid_reverb_level);
 	}
 	else if (strcmp(setting, "z.chorus") == 0)
 	{
-		fluid_synth_set_chorus(FluidSynth, fluidConfig.fluid_chorus_voices, fluidConfig.fluid_chorus_level, fluidConfig.fluid_chorus_speed, fluidConfig.fluid_chorus_depth, fluidConfig.fluid_chorus_type);
+		fluid_synth_set_chorus_group_nr(FluidSynth, -1, fluidConfig.fluid_chorus_voices);
+		fluid_synth_set_chorus_group_level(FluidSynth, -1, fluidConfig.fluid_chorus_level);
+		fluid_synth_set_chorus_group_speed(FluidSynth, -1, fluidConfig.fluid_chorus_speed);
+		fluid_synth_set_chorus_group_depth(FluidSynth, -1, fluidConfig.fluid_chorus_depth);
+		fluid_synth_set_chorus_group_type(FluidSynth, -1, fluidConfig.fluid_chorus_type);
 	}
 	else if (FluidSettingsResultFailed == fluid_settings_setnum(FluidSettings, setting, value))
 	{

--- a/source/mididevices/music_timidity_mididevice.cpp
+++ b/source/mididevices/music_timidity_mididevice.cpp
@@ -267,7 +267,8 @@ bool GUS_SetupConfig(const char* args)
 		if (f)
 		{
 			char test[12] = {};
-			fread(test, 1, 12, f);
+			if (!fread(test, 1, 12, f))
+				;
 			fclose(f);
 			// If the passed file is an SF2 sound font we need to use the special reader that fakes a config for it.
 			if (memcmp(test, "RIFF", 4) == 0 && memcmp(test + 8, "sfbk", 4) == 0)

--- a/source/mididevices/music_timiditypp_mididevice.cpp
+++ b/source/mididevices/music_timiditypp_mididevice.cpp
@@ -209,7 +209,8 @@ bool Timidity_SetupConfig(const char* args)
 		if (f)
 		{
 			char test[12] = {};
-			fread(test, 1, 12, f);
+			if (!fread(test, 1, 12, f))
+				;
 			fclose(f);
 			// If the passed file is an SF2 sound font we need to use the special reader that fakes a config for it.
 			if (memcmp(test, "RIFF", 4) == 0 && memcmp(test + 8, "sfbk", 4) == 0)

--- a/thirdparty/dumb/src/it/itread.c
+++ b/thirdparty/dumb/src/it/itread.c
@@ -621,8 +621,8 @@ int32 _dumb_it_read_sample_data_adpcm4(IT_SAMPLE *sample, DUMBFILE *f)
 	int32 n, len, delta;
 	signed char * ptr, * end;
 	signed char compression_table[16];
-    if (dumbfile_getnc((char *)compression_table, 16, f) != 16)
-        return -1;
+	if (dumbfile_getnc((char *)compression_table, 16, f) != 16)
+		return -1;
 	ptr = (signed char *) sample->data;
 	delta = 0;
 

--- a/thirdparty/dumb/src/it/readmod.c
+++ b/thirdparty/dumb/src/it/readmod.c
@@ -281,15 +281,15 @@ static DUMB_IT_SIGDATA *it_mod_load_sigdata(DUMBFILE *f, int restrict_)
 	int i;
 	uint32 fft;
 
-    if ( dumbfile_seek(f, MOD_FFT_OFFSET, DFS_SEEK_SET) )
-        return NULL;
+	if ( dumbfile_seek(f, MOD_FFT_OFFSET, DFS_SEEK_SET) )
+		return NULL;
 
-    fft = dumbfile_mgetl(f);
-    if (dumbfile_error(f))
-        return NULL;
+	fft = dumbfile_mgetl(f);
+	if (dumbfile_error(f))
+		return NULL;
 
-    if ( dumbfile_seek(f, 0, DFS_SEEK_SET) )
-        return NULL;
+	if ( dumbfile_seek(f, 0, DFS_SEEK_SET) )
+		return NULL;
 
 	sigdata = malloc(sizeof(*sigdata));
 	if (!sigdata) {

--- a/thirdparty/dumb/src/it/readxm.c
+++ b/thirdparty/dumb/src/it/readxm.c
@@ -999,15 +999,15 @@ static DUMB_IT_SIGDATA *it_xm_load_sigdata(DUMBFILE *f, int * version)
 	if (sigdata->speed == 0) sigdata->speed = 6; // Should we? What about tempo?
 	sigdata->tempo            = dumbfile_igetw(f);
 
-    // FT2 always clips restart position against the song length
-    if (sigdata->restart_position > sigdata->n_orders)
-        sigdata->restart_position = sigdata->n_orders;
-    // And FT2 starts playback on order 0, regardless of length,
-    // and only checks if the next order is greater than or equal
-    // to this, not the current pattern. Work around this with
-    // DUMB's playback core by overriding a zero length with one.
-    if (sigdata->n_orders == 0)
-        sigdata->n_orders = 1;
+	// FT2 always clips restart position against the song length
+	if (sigdata->restart_position > sigdata->n_orders)
+		sigdata->restart_position = sigdata->n_orders;
+	// And FT2 starts playback on order 0, regardless of length,
+	// and only checks if the next order is greater than or equal
+	// to this, not the current pattern. Work around this with
+	// DUMB's playback core by overriding a zero length with one.
+	if (sigdata->n_orders == 0)
+		sigdata->n_orders = 1;
 
 	/* sanity checks */
 	// XXX

--- a/thirdparty/fluidsynth/src/midi/fluid_midi.c
+++ b/thirdparty/fluidsynth/src/midi/fluid_midi.c
@@ -2489,7 +2489,10 @@ int fluid_player_set_bpm(fluid_player_t *player, int bpm)
         return FLUID_FAILED; /* to avoid a division by 0 */
     }
 
-    return fluid_player_set_midi_tempo(player, 60000000L / bpm);
+    player->miditempo = 60000000L / bpm;
+
+    fluid_player_update_tempo(player);
+    return FLUID_OK;
 }
 
 /**

--- a/thirdparty/game-music-emu/gme/Ym2612_Nuked.cpp
+++ b/thirdparty/game-music-emu/gme/Ym2612_Nuked.cpp
@@ -1839,7 +1839,7 @@ const char *Ym2612_Nuked_Emu::set_rate(double sample_rate, double clock_rate)
 void Ym2612_Nuked_Emu::reset()
 {
 	Ym2612_NukedImpl::ym3438_t *chip_r = reinterpret_cast<Ym2612_NukedImpl::ym3438_t*>(impl);
-	if ( !chip_r ) Ym2612_NukedImpl::OPN2_Reset( chip_r, static_cast<Bit32u>(prev_sample_rate), static_cast<Bit32u>(prev_clock_rate) );
+	if ( chip_r ) Ym2612_NukedImpl::OPN2_Reset( chip_r, static_cast<Bit32u>(prev_sample_rate), static_cast<Bit32u>(prev_clock_rate) );
 }
 
 void Ym2612_Nuked_Emu::mute_voices(int mask)

--- a/thirdparty/oplsynth/OPL3.cpp
+++ b/thirdparty/oplsynth/OPL3.cpp
@@ -1469,6 +1469,7 @@ double EnvelopeGenerator::getEnvelope(OPL3 *OPL3, int egt, int am) {
 				envelope = 0;
 				stage = DECAY;
 			}
+			[[fallthrough]];
 		case DECAY:   
 			// The decay and release are linear.                
 			if(envelope>envelopeSustainLevel) {
@@ -1477,6 +1478,7 @@ double EnvelopeGenerator::getEnvelope(OPL3 *OPL3, int egt, int am) {
 			}
 			else 
 				stage = SUSTAIN;
+			[[fallthrough]];
 		case SUSTAIN:
 			// The Sustain stage is mantained all the time of the Key ON,
 			// even if we are in non-sustaining mode.

--- a/thirdparty/timidity/instrum_dls.cpp
+++ b/thirdparty/timidity/instrum_dls.cpp
@@ -144,8 +144,10 @@ RIFF_Chunk *LoadRIFF(FILE *src)
 	chunk = new RIFF_Chunk;
 
 	/* Make sure the file is in RIFF format */
-	fread(&chunk->magic, 4, 1, src);
-	fread(&chunk->length, 4, 1, src);
+	if (!fread(&chunk->magic, 4, 1, src))
+		;
+	if (!fread(&chunk->length, 4, 1, src))
+		;
 	chunk->length = LittleLong(chunk->length);
 	if ( chunk->magic != RIFF ) {
 		__Sound_SetError("Not a RIFF file");


### PR DESCRIPTION
This PR eliminates build warnings on a Linux build using GCC version 13.2.0-23ubuntu4, as of September 2024.

* In the code that uses FluidSynth, there are calls to functions for setting parameters that have been deprecated. This PR splits these into calls to the recommended replacements.
* There are several calls to `fread` that ignore the return value. This PR changes the code so that it still ignores the return value, but it does it explicitly with a `if` statement with an empty body.
* Marked a couple of `switch` `case` blocks as being explicit fallthrough to the next `case`.

One of the warnings was indicative of an actual bug, I believe. In Ym2612_Nuked.cpp, the definition of the Ym2612_Nuked_Emu::reset function calls OPN2_Reset on `chip_r` only if `chip_r` is `NULL`. I'm pretty sure this should be the other way around, and making it so that it only calls it when `chip_r` is _not_ `NULL` eliminates a warning.

With these changes, which I believe do not alter functionality in any way, the ZMusic build runs through with no warnings at all. Could possibly add `-Werror` to the build.