### PR TITLE
Fix MinGW builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,11 @@ endif()
 # Initialize our list of find_package dependencies for configure_package_config_file
 set(ZMUSIC_PACKAGE_DEPENDENCIES "" CACHE INTERNAL "")
 
+if (WIN32 AND MINGW)
+	add_compile_definitions(-D_UNICODE -DUNICODE)
+	add_compile_definitions(-D__USE_MINGW_ANSI_STDIO=1)
+endif()
+
 add_subdirectory(thirdparty)
 add_subdirectory(source)
 

--- a/source/mididevices/music_win_mididevice.cpp
+++ b/source/mididevices/music_win_mididevice.cpp
@@ -39,6 +39,7 @@
 #include <mmsystem.h>
 #include <algorithm>
 #include <mutex>
+#include <stdexcept>
 #include <assert.h>
 
 // HEADER FILES ------------------------------------------------------------

--- a/thirdparty/fluidsynth/src/utils/win32_glibstubs.h
+++ b/thirdparty/fluidsynth/src/utils/win32_glibstubs.h
@@ -4,6 +4,7 @@
 #ifdef WIN32
 #include <Windows.h>
 #include <assert.h>
+#include <stdio.h>
 
 /* Miscellaneous stubs */
 #define GLIB_CHECK_VERSION(x, y, z) 0 /* Evaluate to 0 to get FluidSynth to use the "old" thread API */
@@ -25,6 +26,9 @@ typedef void *gpointer;
 #define G_LIKELY(expr) (expr)
 #define G_UNLIKELY(expr) (expr)
 #endif
+
+#define g_vsnprintf(b, c, f, a) vsnprintf(b, c, f, a)
+#define g_snprintf(b, c, f, ...) snprintf(b, c, f, __VA_ARGS__)
 
 #define g_return_val_if_fail(expr, val) if (expr) {} else { return val; }
 #define g_clear_error(err) do {} while (0)


### PR DESCRIPTION
1. Include `<stdexcept>` for `music_win_mididevice.cpp`
2. Force `UNICODE` and `_UNICODE` defines.
3. Also define `__USE_MINGW_ANSI_STDIO` and redirect glib printf calls to C standard library.

Fixes #59.