### PR TITLE
Fix libxmp playback

### DIFF
--- a/source/streamsources/music_libxmp.cpp
+++ b/source/streamsources/music_libxmp.cpp
@@ -126,7 +126,7 @@ bool XMPSong::SetSubsong(int subsong)
 
 bool XMPSong::GetData(void *buffer, size_t len)
 {
-	if ((len / 4) < int16_buffer.size())
+	if ((len / 4) > int16_buffer.size())
 		int16_buffer.resize(len / 4);
 
 	int ret = xmp_play_buffer(context, (void*)int16_buffer.data(), len / 2, m_Looping? INT_MAX : 0);


### PR DESCRIPTION
Fixes crashing when the int16_buffer is smaller than the desired len. Particularly, I was seeing the int16_buffer with a size of 0. 

I experienced a crash when attempting to start any level with the [Doom 64: Unseen Evil (v1.0.3) mod](https://www.moddb.com/mods/doom-64-unseen-evil/downloads/doom-64-unseen-evil-v103).

```
GZDoom g4.14.0-m - 2024-12-17 14:17:50 -0500 - SDL version
Compiled on Dec 20 2024

OS: Arch Linux, Linux 6.12.9-zen1-1-zen on x86_64
GZDoom version g4.14.0-m
W_Init: Init WADfiles.
adding /usr/share/gzdoom/gzdoom.pk3, 689 lumps
adding /usr/share/gzdoom/game_support.pk3, 3308 lumps
adding /home/ar/.config/gzdoom/DOOM.WAD, 2306 lumps
adding /usr/share/gzdoom/game_widescreen_gfx.pk3, 214 lumps
adding D64UnseenEvil-v1.0.3.pk3, 3686 lumps
S_Init: Setting up sound.
I_InitSound: Initializing OpenAL
  Opened device UMC404HD 192k Pro
  EFX enabled
Music "orb" not found
Using video driver x11
Number of detected displays 1 .
Creating window [3072x1728] on adapter 0
Vulkan device: AMD Radeon RX 6900 XT (RADV NAVI21)
Vulkan device type: discrete gpu
Vulkan version: 1.3.296 (api) 24.3.3 (driver)
Max. texture size: 16384
Max. uniform buffer range: -1
Min. uniform buffer offset alignment: 4
Resolution: 640 x 480
I_Init: Setting up machine state.
CPU speed: 3400 MHz
CPU Vendor ID: AuthenticAMD
  Name: AMD Ryzen 9 5950X 16-Core Processor
  Family 25 (25), Model 33, Stepping 2
  Features: SSE2 SSE3 SSSE3 SSE4.1 SSE4.2 AVX AVX2 F16C FMA3 BMI1 BMI2 HyperThreading
V_Init: allocate screen.
ST_Init: Init startup screen.
Checking cmd-line parameters...
S_InitData: Load sound definitions.
G_ParseMapInfo: Load map definitions.
Texman.Init: Init texture manager.
Invalid data encountered for texture D64UnseenEvil-v1.0.3.pk3:textures/texture_readme.txt
ParseTeamInfo: Load team definitions.
LoadActors: Load actor definitions.
Script warning, "D64UnseenEvil-v1.0.3.pk3:zscript/enemies/zombies.zsc" line 71:
Accessing deprecated function A_PlaySound - deprecated since 4.3.0, Use A_StartSound() instead
Script warning, "D64UnseenEvil-v1.0.3.pk3:zscript/enemies/imps.zsc" line 96:
Accessing deprecated function A_PlaySound - deprecated since 4.3.0, Use A_StartSound() instead
Script warning, "D64UnseenEvil-v1.0.3.pk3:zscript/enemies/brusiers.zsc" line 37:
Truncation of floating point constant 29.268288
Script warning, "D64UnseenEvil-v1.0.3.pk3:zscript/d64ue/enemies/cyberdemon.zsc" line 34:
Truncation of floating point constant 53.658528
Script warning, "D64UnseenEvil-v1.0.3.pk3:zscript/d64ue/enemies/cyberdemon.zsc" line 35:
Truncation of floating point constant 32.940000
Script warning, "D64UnseenEvil-v1.0.3.pk3:zscript/hud.zsc" line 32:
Accessing deprecated function S_Sound - deprecated since 4.3.0, Use S_StartSound() instead
Script warning, "D64UnseenEvil-v1.0.3.pk3:zscript/d64ue/redemption_denied.zsc" line 146:
Comparison between signed and unsigned value
Script warning, "D64UnseenEvil-v1.0.3.pk3:zscript/d64ue/redemption_denied.zsc" line 218:
Comparison between signed and unsigned value
Script warning, "D64UnseenEvil-v1.0.3.pk3:zscript/d64ue/redemption_denied.zsc" line 238:
Comparison between signed and unsigned value
Script warning, "D64UnseenEvil-v1.0.3.pk3:zscript/enemies/arachnotron.zsc" line 65:
Truncation of floating point constant 17.073168
Script warning, "D64UnseenEvil-v1.0.3.pk3:zscript/enemies/arachnotron.zsc" line 66:
Truncation of floating point constant 14.640000
11 warnings while parsing scripts
script parsing took 375.02 ms
Brightmap 'textures/comp/d64_brownlever_bm' not found in texture 'TEXTURES/COMP/D64_BROWNLEVER_ON'
Brightmap 'textures/comp/d64_brownlever_bm' not found in texture 'TEXTURES/COMP/D64_CEMENTLEVER_ON'
R_Init: Init Doom refresh subsystem.
DecalLibrary: Load decals.
M_Init: Init menus.
P_Init: Init Playloop state.
Script error, "D64UnseenEvil-v1.0.3.pk3:models/maps/map30_map30.obj" line 532:
Material Default (#0) not found.
Script error, "D64UnseenEvil-v1.0.3.pk3:models/maps/map30_map30.obj" line 588:
Material SFALL4 (#2) not found.
Script error, "D64UnseenEvil-v1.0.3.pk3:models/maps/map30_map30.obj" line 626:
Material BFALL1 (#6) not found.
Script error, "D64UnseenEvil-v1.0.3.pk3:models/maps/map30_map30.obj" line 644:
Material Default (#10) not found.
ParseSBarInfo: Loading custom status bar definition.
D_CheckNetGame: Checking network game status.
player 1 of 1 (1 nodes)

----------------------------------------

TITLEMAP - Title Screen


----------------------------------------

E1M1 - Hangar


/usr/include/c++/14.2.1/bits/stl_vector.h:1130: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = short int; _Alloc = std::allocator<short int>; reference = short int&; size_type = long unsigned int]: Assertion '__n < this->size()' failed.
```

Resolves https://github.com/ZDoom/gzdoom/issues/2834