### PR TITLE
Fix building with no sndfile support at all

### DIFF
--- a/source/decoder/sndfile_decoder.h
+++ b/source/decoder/sndfile_decoder.h
@@ -43,6 +43,8 @@ private:
     static sf_count_t file_tell(void *user_data);
 };
 
+#else
+#include "../thirdparty/sndfile.h"
 #endif
 
 #endif /* SNDFILE_DECODER_H */


### PR DESCRIPTION
The stub functions still reference `SNDFILE`, so we still need to include the bundled header in this case. Otherwise, you get this error:

```
ZMusic-1.1.14/source/decoder/sndfile_decoder.cpp:243:12: error: ‘SNDFILE’ does not name a type; did you mean ‘ENFILE’?
  243 | extern "C" SNDFILE * sf_open_virtual(SF_VIRTUAL_IO * sfvirtual, int mode, SF_INFO * sfinfo, void* user_data)
      |            ^~~~~~~
      |            ENFILE
ZMusic-1.1.14/source/decoder/sndfile_decoder.cpp:248:24: warning: ‘sf_strerror’ initialized and declared ‘extern’
  248 | extern "C" const char* sf_strerror(SNDFILE * sndfile)
      |                        ^~~~~~~~~~~
ZMusic-1.1.14/source/decoder/sndfile_decoder.cpp:248:36: error: ‘SNDFILE’ was not declared in this scope; did you mean ‘ENFILE’?
  248 | extern "C" const char* sf_strerror(SNDFILE * sndfile)
      |                                    ^~~~~~~
      |                                    ENFILE
ZMusic-1.1.14/source/decoder/sndfile_decoder.cpp:248:46: error: ‘sndfile’ was not declared in this scope
  248 | extern "C" const char* sf_strerror(SNDFILE * sndfile)
      |                                              ^~~~~~~
ZMusic-1.1.14/source/decoder/sndfile_decoder.cpp:253:12: error: ‘sf_count_t’ does not name a type
  253 | extern "C" sf_count_t sf_readf_short(SNDFILE * sndfile, short* ptr, sf_count_t frames)
      |            ^~~~~~~~~~
ZMusic-1.1.14/source/decoder/sndfile_decoder.cpp:258:16: warning: ‘sf_close’ initialized and declared ‘extern’
  258 | extern "C" int sf_close(SNDFILE * sndfile)
      |                ^~~~~~~~
ZMusic-1.1.14/source/decoder/sndfile_decoder.cpp:258:25: error: ‘SNDFILE’ was not declared in this scope; did you mean ‘ENFILE’?
  258 | extern "C" int sf_close(SNDFILE * sndfile)
      |                         ^~~~~~~
      |                         ENFILE
ZMusic-1.1.14/source/decoder/sndfile_decoder.cpp:258:35: error: ‘sndfile’ was not declared in this scope
  258 | extern "C" int sf_close(SNDFILE * sndfile)
      |                                   ^~~~~~~
[2/6] Building CXX object source/CMakeFiles/zmusic.dir/decoder/sndfile_decoder.cpp.o
```