### PR TITLE
Reland GS Reset, now with a condition.

### DIFF
--- a/source/musicformats/music_midi.cpp
+++ b/source/musicformats/music_midi.cpp
@@ -815,13 +815,25 @@ int MIDIStreamer::FillBuffer(int buffer_num, int max_events, uint32_t max_time)
 	if (InitialPlayback)
 	{
 		InitialPlayback = false;
-		// Send the GS System Reset SysEx message.
+		// Send the GM System Enable SysEx message.
 		events[0] = 0;								// dwDeltaTime
 		events[1] = 0;								// dwStreamID
 		events[2] = (MEVENT_LONGMSG << 24) | 6;		// dwEvent
 		events[3] = MAKE_ID(0xf0, 0x7e, 0x7f, 0x09);	// dwParms[0]
 		events[4] = MAKE_ID(0x01, 0xf7, 0x00, 0x00);	// dwParms[1]
 		events += 5;
+
+		if (MIDI->CanHandleSysex())
+		{
+			// Send the GS DT1 MODE SET GS Reset SysEx message.
+			events[0] = 0;									// dwDeltaTime
+			events[1] = 0;									// dwStreamID
+			events[2] = (MEVENT_LONGMSG << 24) | 11;		// dwEvent
+			events[3] = MAKE_ID(0xf0, 0x41, 0x7f, 0x42);	// dwParms[0]
+			events[4] = MAKE_ID(0x12, 0x40, 0x00, 0x7f);	// dwParms[1]
+			events[5] = MAKE_ID(0x00, 0x41, 0xf7, 0x00);	// dwParms[2]
+			events += 6;
+		}
 
 		// Send the full master volume SysEx message.
 		events[0] = 0;								// dwDeltaTime


### PR DESCRIPTION
MIDI Device is now asked whether it can handle SysEx before sending the GS DT1 MODE SET GS Reset SysEx message.

This fixes #70 without reintroducing the issue that caused me to add GS Reset message in the first place.

I've verified Bella2.wad MAP19 with MSGS and dbp37_augzen.wad MAP01 with FluidSynth, both music tracks are playing as expected.

Caveat: this change removes GS playback option from any external synth on Windows, since they all go through WinMIDIDevice, a CVAR may be introduced to allow GS Reset to be forced in, if user desires it.