### PR TITLE
Enable dynamic sample loading in FluidSynth

### DIFF
--- a/source/mididevices/music_fluidsynth_mididevice.cpp
+++ b/source/mididevices/music_fluidsynth_mididevice.cpp
@@ -117,6 +117,7 @@ FluidSynthMIDIDevice::FluidSynthMIDIDevice(int samplerate, std::vector<std::stri
 	{
 		throw std::runtime_error("Failed to create FluidSettings.\n");
 	}
+	fluid_settings_setint(FluidSettings, "synth.dynamic-sample-loading", 1);
 	fluid_settings_setnum(FluidSettings, "synth.sample-rate", SampleRate);
 	fluid_settings_setnum(FluidSettings, "synth.gain", fluidConfig.fluid_gain);
 	fluid_settings_setint(FluidSettings, "synth.reverb.active", fluidConfig.fluid_reverb);

--- a/thirdparty/fluidsynth/src/sfloader/fluid_defsfont.c
+++ b/thirdparty/fluidsynth/src/sfloader/fluid_defsfont.c
@@ -317,25 +317,9 @@ const char *fluid_defsfont_get_name(fluid_defsfont_t *defsfont)
 int fluid_defsfont_load_sampledata(fluid_defsfont_t *defsfont, SFData *sfdata, fluid_sample_t *sample)
 {
     int num_samples;
-    unsigned int source_end = sample->source_end;
-
-    /* For uncompressed samples we want to include the 46 zero sample word area following each sample
-     * in the Soundfont. Otherwise samples with loopend > end, which we have decided not to correct, would
-     * be corrected after all in fluid_sample_sanitize_loop */
-    if(!(sample->sampletype & FLUID_SAMPLETYPE_OGG_VORBIS))
-    {
-        source_end += 46;  /* Length of zero sample word after each sample, according to SF specs */
-
-        /* Safeguard against Soundfonts that are not quite valid and don't include 46 sample words after the
-         * last sample */
-        if(source_end >= (defsfont->samplesize  / sizeof(short)))
-        {
-            source_end = defsfont->samplesize  / sizeof(short);
-        }
-    }
 
     num_samples = fluid_samplecache_load(
-                      sfdata, sample->source_start, source_end, sample->sampletype,
+                      sfdata, sample->source_start, sample->source_end, sample->sampletype,
                       defsfont->mlock, &sample->data, &sample->data24);
 
     if(num_samples < 0)


### PR DESCRIPTION
This change prevents unnecessary presets from being loaded into memory when using internal FluidSynth. This dramatically reduces RAM consumption and diminishes loading times when using big soundfonts.

For instance, I'm using a 1.5GB sf2 file, and enabling dynamic sample loading reduced memory usage of gzdoom.exe process from ~3GB to ~1.7GB, and loading time for levels went from 3-7 seconds to ~1.

This change allows even gigantic soundfonts, such as Apollo GMGS (~4GB), to be used with little concern.