### PR TITLE
Fix build under Solaris

### DIFF
--- a/thirdparty/dumb/CMakeLists.txt
+++ b/thirdparty/dumb/CMakeLists.txt
@@ -2,6 +2,12 @@ make_release_only()
 
 include(CheckFunctionExists)
 include(CheckCXXCompilerFlag)
+include(CheckIncludeFile)
+
+check_include_file(alloca.h HAVE_ALLOCA_H)
+if(HAVE_ALLOCA_H)
+add_compile_definitions(HAVE_ALLOCA_H=1)
+endif()
 
 add_library(dumb OBJECT
 	src/core/unload.c

--- a/thirdparty/dumb/src/helpers/lpc.c
+++ b/thirdparty/dumb/src/helpers/lpc.c
@@ -49,6 +49,10 @@ Carsten Bormann
 #include "internal/stack_alloc.h"
 #include "internal/lpc.h"
 
+#ifdef HAVE_ALLOCA_H
+#include <alloca.h>
+#endif
+
 /* Autocorrelation LPC coeff generation algorithm invented by
    N. Levinson in 1947, modified by J. Durbin in 1959. */
 


### PR DESCRIPTION
OpenIndiana's GCC gives an error when using an implicit builtin alloca